### PR TITLE
Xbox: define HAVE_STDIO_H

### DIFF
--- a/include/SDL_config_xbox.h
+++ b/include/SDL_config_xbox.h
@@ -32,6 +32,7 @@
 
 #define HAVE_STDARG_H   1
 #define HAVE_STDDEF_H   1
+#define HAVE_STDIO_H   1
 #define HAVE_MALLOC
 #define STDC_HEADERS 1
 


### PR DESCRIPTION
Since nxdk has `stdio.h` since a while back, it only makes sense to make use of it.