### PR TITLE
Overhaul Xbox config to fully utilize the libc

### DIFF
--- a/include/SDL_config_xbox.h
+++ b/include/SDL_config_xbox.h
@@ -1,6 +1,6 @@
 /*
   Simple DirectMedia Layer
-  Copyright (C) 1997-2016 Sam Lantinga <slouken@libsdl.org>
+  Copyright (C) 1997-2019 Sam Lantinga <slouken@libsdl.org>
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages
@@ -19,39 +19,91 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#ifndef _SDL_config_minimal_h
-#define _SDL_config_minimal_h
+#ifndef _SDL_config_xbox_h
+#define _SDL_config_xbox_h
 
 #include "SDL_platform.h"
 
-/**
- *  \file SDL_config_minimal.h
- *
- *  This is the minimal configuration that can be used to build SDL.
- */
+#define HAVE_LIBC 1
 
-#define HAVE_STDARG_H   1
-#define HAVE_STDDEF_H   1
-#define HAVE_STDIO_H   1
-#define HAVE_MALLOC
+/* C headers */
 #define STDC_HEADERS 1
-
-/* Most everything except Visual Studio 2008 and earlier has stdint.h now */
-#if defined(_MSC_VER) && (_MSC_VER < 1600)
-/* Here are some reasonable defaults */
-typedef unsigned int size_t;
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef signed short int16_t;
-typedef unsigned short uint16_t;
-typedef signed int int32_t;
-typedef unsigned int uint32_t;
-typedef signed long long int64_t;
-typedef unsigned long long uint64_t;
-typedef unsigned long uintptr_t;
-#else
+#define HAVE_STDIO_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STDDEF_H 1
+#define HAVE_STDARG_H 1
+#define HAVE_STRING_H 1
+#define HAVE_INTTYPES_H 1
 #define HAVE_STDINT_H 1
-#endif /* Visual Studio 2008 */
+#define HAVE_CTYPE_H 1
+#define HAVE_MATH_H 1
+
+/* C library features */
+#define HAVE_MALLOC 1
+#define HAVE_CALLOC 1
+#define HAVE_REALLOC 1
+#define HAVE_FREE 1
+#undef HAVE_ALLOCA
+#define HAVE_GETENV 1
+#define HAVE_QSORT 1
+#define HAVE_ABS 1
+#define HAVE_MEMSET 1
+#define HAVE_MEMCPY 1
+#define HAVE_MEMMOVE 1
+#define HAVE_MEMCMP 1
+#define HAVE_STRLEN 1
+#define HAVE_STRCHR 1
+#define HAVE_STRRCHR 1
+#define HAVE_STRSTR 1
+#define HAVE_STRTOL 1
+#define HAVE_STRTOUL 1
+#define HAVE_STRTOLL 1
+#define HAVE_STRTOULL 1
+#undef HAVE_STRTOD
+#define HAVE_ATOI 1
+#define HAVE_STRCMP 1
+#define HAVE_STRNCMP 1
+#undef HAVE_STRCASECMP
+#undef HAVE_STRNCASECMP
+#define HAVE_SSCANF 1
+#define HAVE_SNPRINTF 1
+#define HAVE_VSNPRINTF 1
+#define HAVE__EXIT 1
+
+/* math library features */
+#define HAVE_ACOS 1
+#define HAVE_ACOSF 1
+#define HAVE_ASIN 1
+#define HAVE_ASINF 1
+#define HAVE_ATAN 1
+#define HAVE_ATANF 1
+#define HAVE_ATAN2 1
+#define HAVE_ATAN2F 1
+#define HAVE_CEILF 1
+#undef HAVE__COPYSIGN
+#define HAVE_COS 1
+#define HAVE_COSF 1
+#define HAVE_EXP 1
+#define HAVE_EXPF 1
+#define HAVE_FABS 1
+#define HAVE_FABSF 1
+#undef HAVE_FLOOR
+#undef HAVE_FLOORF
+#define HAVE_FMOD 1
+#define HAVE_FMODF 1
+#define HAVE_LOG 1
+#define HAVE_LOGF 1
+#define HAVE_LOG10 1
+#define HAVE_LOG10F 1
+#define HAVE_POW 1
+#define HAVE_POWF 1
+#define HAVE_SIN 1
+#define HAVE_SINF 1
+#define HAVE_SQRT 1
+#define HAVE_SQRTF 1
+#define HAVE_TAN 1
+#define HAVE_TANF 1
+
 
 #ifdef __GNUC__
 #define HAVE_GCC_SYNC_LOCK_TEST_AND_SET 1
@@ -84,4 +136,4 @@ typedef unsigned long uintptr_t;
 /* Enable the dummy filesystem driver (src/filesystem/dummy/\*.c) */
 #define SDL_FILESYSTEM_DUMMY  1
 
-#endif /* _SDL_config_minimal_h */
+#endif /* _SDL_config_xbox_h */


### PR DESCRIPTION
I went through all feature `#define`s I could find and set them properly (+ minor cleanup of surrounding stuff). This means that SDL now utilizes our libc better, which not only reduces executable size a bit, but also removes the need for our SDL-samples to provide a `_exit()` function (XboxDev/nxdk#97).