### PR TITLE
video: Change include path for debug.h

### DIFF
--- a/src/video/xbox/SDL_xbframebuffer.c
+++ b/src/video/xbox/SDL_xbframebuffer.c
@@ -32,7 +32,7 @@
 #include <pbkit/pbkit.h>
 #include <hal/xbox.h>
 #include <hal/video.h>
-#include <xboxrt/debug.h>
+#include <debug.h>
 
 
 //Screen dimension constants


### PR DESCRIPTION
In preparation for restructuring the nxdk runtime library (which is a preparation for libc++), this changes the include path for `debug.h`. It's currently not necessary to use the full path, and with my upcoming changes, the absolute path changes.