### PR TITLE
build: Add dummy drivers to Makefile.xbox

### DIFF
--- a/Makefile.xbox
+++ b/Makefile.xbox
@@ -1,12 +1,23 @@
 SDL_DIR = $(NXDK_DIR)/lib/sdl/SDL2
+
+# Based on Makefile.minimal (some backends adapted for Xbox)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/*.c)
+SDL_SRCS += $(wildcard $(SDL_DIR)/src/audio/*.c)
+SDL_SRCS += $(wildcard $(SDL_DIR)/src/audio/dummy/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/cpuinfo/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/events/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/file/*.c)
+SDL_SRCS += $(wildcard $(SDL_DIR)/src/haptic/*.c)
+SDL_SRCS += $(wildcard $(SDL_DIR)/src/haptic/dummy/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/joystick/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/joystick/xbox/*.c)
+SDL_SRCS += $(wildcard $(SDL_DIR)/src/loadso/dummy/*.c)
+SDL_SRCS += $(wildcard $(SDL_DIR)/src/power/*.c)
+SDL_SRCS += $(wildcard $(SDL_DIR)/src/filesystem/dummy/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/render/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/render/software/*.c)
+SDL_SRCS += $(wildcard $(SDL_DIR)/src/sensor/*.c)
+SDL_SRCS += $(wildcard $(SDL_DIR)/src/sensor/dummy/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/stdlib/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/thread/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/thread/generic/*.c)
@@ -15,6 +26,8 @@ SDL_SRCS += $(wildcard $(SDL_DIR)/src/timer/dummy/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/video/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/video/xbox/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/video/yuv2rgb/*.c)
+
+# Additions for Xbox
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/libm/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/atomic/*.c)
 


### PR DESCRIPTION
This change was untested. However, compilation of the nxdk SDL example still worked.

Someone should test the dummy implementations, and the power API (which appears to use a different method of loading backends).

Closes #9 