### PR TITLE
build: Add CXXFLAGS

### DIFF
--- a/Makefile.xbox
+++ b/Makefile.xbox
@@ -21,3 +21,6 @@ SDL_SRCS += $(wildcard $(SDL_DIR)/src/atomic/*.c)
 SRCS += $(SDL_SRCS)
 CFLAGS += -I$(SDL_DIR)/include \
           -DXBOX
+
+CXXFLAGS += -I$(SDL_DIR)/include \
+          -DXBOX


### PR DESCRIPTION
Building C++ projects broke as `SDL.h` couldn't be found.
This is a suggestion for a fix.