### PR TITLE
video: Use current video mode for fb size

### DIFF
--- a/src/video/xbox/SDL_xbframebuffer_c.h
+++ b/src/video/xbox/SDL_xbframebuffer_c.h
@@ -19,9 +19,31 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 #include "../../SDL_internal.h"
+#include "SDL_pixels.h"
+#include <assert.h>
 
 extern int SDL_XBOX_CreateWindowFramebuffer(_THIS, SDL_Window * window, Uint32 * format, void ** pixels, int *pitch);
 extern int SDL_XBOX_UpdateWindowFramebuffer(_THIS, SDL_Window * window, const SDL_Rect * rects, int numrects);
 extern void SDL_XBOX_DestroyWindowFramebuffer(_THIS, SDL_Window * window);
+
+static inline
+Uint32 pixelFormatSelector(int bpp) {
+    Uint32 ret_val = 0;
+    switch(bpp) {
+    case 15:
+        ret_val = SDL_PIXELFORMAT_ARGB1555;
+        break;
+    case 16:
+        ret_val = SDL_PIXELFORMAT_RGB565;
+        break;
+    case 32:
+        ret_val = SDL_PIXELFORMAT_RGB888;
+        break;
+    default:
+        assert(0);
+        break;
+    }
+    return ret_val;
+}
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/xbox/SDL_xbvideo.c
+++ b/src/video/xbox/SDL_xbvideo.c
@@ -106,19 +106,18 @@ VideoBootStrap XBOX_bootstrap = {
 };
 
 
-#include <pbkit/pbkit.h>
-#include <hal/xbox.h>
 #include <hal/video.h>
 int
 XBOX_VideoInit(_THIS)
 {
     SDL_DisplayMode mode;
+    VIDEO_MODE vm = XVideoGetMode();
 
-    /* Use a fake 32-bpp desktop mode */
-    mode.format = SDL_PIXELFORMAT_RGB888;
-    mode.w = 640;
-    mode.h = 480;
-    mode.refresh_rate = 30;
+    /* Select display mode based on Xbox video mode */
+    mode.format = pixelFormatSelector(vm.bpp);
+    mode.w = vm.width;
+    mode.h = vm.height;
+    mode.refresh_rate = vm.refresh;
     mode.driverdata = NULL;
     if (SDL_AddBasicVideoDisplay(&mode) < 0) {
         return -1;


### PR DESCRIPTION
This allows for other video modes than 640x480 to be used.
Tested working with NevolutionX.

Fixes #13