### PR TITLE
audio: Inherit dummy driver as xbox driver

### DIFF
--- a/Makefile.xbox
+++ b/Makefile.xbox
@@ -3,7 +3,7 @@ SDL_DIR = $(NXDK_DIR)/lib/sdl/SDL2
 # Based on Makefile.minimal (some backends adapted for Xbox)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/audio/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/audio/dummy/*.c)
+SDL_SRCS += $(wildcard $(SDL_DIR)/src/audio/xbox/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/cpuinfo/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/events/*.c)
 SDL_SRCS += $(wildcard $(SDL_DIR)/src/file/*.c)

--- a/include/SDL_config_xbox.h
+++ b/include/SDL_config_xbox.h
@@ -109,8 +109,8 @@
 #define HAVE_GCC_SYNC_LOCK_TEST_AND_SET 1
 #endif
 
-/* Enable the dummy audio driver (src/audio/dummy/\*.c) */
-#define SDL_AUDIO_DISABLED  1
+/* Enable the dummy audio driver (src/audio/xbox/\*.c) */
+#define SDL_AUDIO_DRIVER_XBOX 1
 
 /* Enable the Xbox joystick driver (src/joystick/xbox/\*.c) */
 #define SDL_JOYSTICK_XBOX   1

--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -107,6 +107,9 @@ static const AudioBootStrap *const bootstrap[] = {
 #if SDL_AUDIO_DRIVER_DISK
     &DISKAUDIO_bootstrap,
 #endif
+#if SDL_AUDIO_DRIVER_XBOX
+    &XBOXAUDIO_bootstrap,
+#endif
 #if SDL_AUDIO_DRIVER_DUMMY
     &DUMMYAUDIO_bootstrap,
 #endif

--- a/src/audio/SDL_sysaudio.h
+++ b/src/audio/SDL_sysaudio.h
@@ -208,6 +208,7 @@ extern AudioBootStrap ANDROIDAUDIO_bootstrap;
 extern AudioBootStrap openslES_bootstrap;
 extern AudioBootStrap PSPAUDIO_bootstrap;
 extern AudioBootStrap EMSCRIPTENAUDIO_bootstrap;
+extern AudioBootStrap XBOXAUDIO_bootstrap;
 
 #endif /* SDL_sysaudio_h_ */
 

--- a/src/audio/xbox/SDL_xboxaudio.c
+++ b/src/audio/xbox/SDL_xboxaudio.c
@@ -1,0 +1,7 @@
+// Copy of dummy driver, but always allowed by default (demand_only = 0)
+
+#include "../dummy/SDL_dummyaudio.c"
+
+AudioBootStrap XBOXAUDIO_bootstrap = {
+    "xbox", "Original Xbox audio driver", DUMMYAUDIO_Init, 0
+};


### PR DESCRIPTION
I noticed that this fails: `SDL_Init(SDL_INIT_AUDIO)`.

This shouldn't happen as I already added dummy drivers in #9.
Unfortunately, it was incomplete (which I didn't know at the time).

There were 2 independent problems which break SDL audio:

- Audio was disabled, and no backend was enabled: Config had `SDL_AUDIO_DISABLED 1` with a misleading comment (implying the dummy would be active); it should be `SDL_AUDIO_DRIVER_DUMMY`.
- Even if the audio is enabled, no backend would be found: The dummy backend has `demand_only = 1`. This means will be rejected unless explicitly requested through environment variables (which are always `NULL` in nxdk at the moment).

As a solution, I add a source file which includes the dummy driver; however, the dummy backend with `demand_only = 1` is never registered itself.
Instead it is registered as another backend ("xbox") with `demand_only = 0`.
Accordingly, I use `SDL_AUDIO_DRIVER_XBOX` in our config.

I'm not sure about the commit title - suggestions welcome.

---

I have smoke-tested this by using this in the SDL sample `main` function:

```c
if (SDL_Init(SDL_INIT_AUDIO) == -1) {
  assert(0); // Triggered on master due to "missing" audio backend; doesn't trigger with this PR
}
```

*(needs `#include <assert.h>`)*

Please confirm that this works correctly (my nxdk and SDL trees also had other changes at the time).