### PR TITLE
build: Fix C++ header compatibility

### DIFF
--- a/include/SDL_config.h
+++ b/include/SDL_config.h
@@ -29,7 +29,7 @@
  */
 
 /* Add any platform that doesn't build using the configure system. */
-#if defined(__WIN32__)
+#if defined(__WIN32__) && !defined(__XBOX__)
 #include "SDL_config_windows.h"
 #elif defined(__WINRT__)
 #include "SDL_config_winrt.h"

--- a/include/SDL_platform.h
+++ b/include/SDL_platform.h
@@ -70,11 +70,12 @@
 #define XBOX 1
 #undef __XBOX__
 #define __XBOX__ 1
-/* Don't assume we're building for Windows when targeting Xbox */
-#undef WIN32
-#undef _WIN32
-#undef _MSC_VER
-#define __GNUC__ 4
+/* clang doesn't like the SDL packing pragma headers */
+#pragma GCC diagnostic ignored "-Wpragma-pack"
+/* Disable SDL's weird feature of renaming main() */
+#define SDL_MAIN_HANDLED
+/* Disable SDL's inclusion of sal.h */
+#define SDL_DISABLE_ANALYZE_MACROS
 #endif
 
 #if defined(__APPLE__)

--- a/src/SDL_internal.h
+++ b/src/SDL_internal.h
@@ -21,6 +21,14 @@
 #ifndef SDL_internal_h_
 #define SDL_internal_h_
 
+/* Workaround to prevent SDL from trying to use all kinds of Windows features not available when building for Xbox */
+#if defined(XBOX)
+#undef WIN32
+#undef _WIN32
+#undef _MSC_VER
+#define __GNUC__ 4
+#endif
+
 /* Many of SDL's features require _GNU_SOURCE on various platforms */
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE


### PR DESCRIPTION
This attempts to solve the header compatibility issues caused by our SDL port's behavior of undefining `WIN32`, `_WIN32` and `_MSC_VER`.

One solution could've been to integrate the "are we building for Xbox" condition into all `#if` statements in the SDL codebase, but I feared that this might introduce countless merge conflicts when we update our fork in the future. So instead, these changes merely move the hack, so the preprocessor variables get only undefined when building SDL itself, and not in its public headers. It required some other minor changes, but it's still pretty small overall.

I tested this with a small C++ program to make sure the header conflict is gone now.

Fixes #18.