### PR TITLE
Build SDL2 as a library

### DIFF
--- a/Makefile.xbox
+++ b/Makefile.xbox
@@ -1,39 +1,52 @@
-SDL_DIR = $(NXDK_DIR)/lib/sdl/SDL2
+SDL2_DIR = $(NXDK_DIR)/lib/sdl/SDL2
 
 # Based on Makefile.minimal (some backends adapted for Xbox)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/audio/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/audio/xbox/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/cpuinfo/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/events/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/file/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/haptic/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/haptic/dummy/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/joystick/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/joystick/xbox/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/loadso/dummy/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/power/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/filesystem/dummy/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/render/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/render/software/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/sensor/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/sensor/dummy/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/stdlib/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/thread/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/thread/windows/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/timer/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/timer/windows/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/video/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/video/xbox/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/video/yuv2rgb/*.c)
+SDL2_SRCS := \
+	$(wildcard $(SDL2_DIR)/src/*.c) \
+	$(wildcard $(SDL2_DIR)/src/audio/*.c) \
+	$(wildcard $(SDL2_DIR)/src/audio/xbox/*.c) \
+	$(wildcard $(SDL2_DIR)/src/cpuinfo/*.c) \
+	$(wildcard $(SDL2_DIR)/src/events/*.c) \
+	$(wildcard $(SDL2_DIR)/src/file/*.c) \
+	$(wildcard $(SDL2_DIR)/src/haptic/*.c) \
+	$(wildcard $(SDL2_DIR)/src/haptic/dummy/*.c) \
+	$(wildcard $(SDL2_DIR)/src/joystick/*.c) \
+	$(wildcard $(SDL2_DIR)/src/joystick/xbox/*.c) \
+	$(wildcard $(SDL2_DIR)/src/loadso/dummy/*.c) \
+	$(wildcard $(SDL2_DIR)/src/power/*.c) \
+	$(wildcard $(SDL2_DIR)/src/filesystem/dummy/*.c) \
+	$(wildcard $(SDL2_DIR)/src/render/*.c) \
+	$(wildcard $(SDL2_DIR)/src/render/software/*.c) \
+	$(wildcard $(SDL2_DIR)/src/sensor/*.c) \
+	$(wildcard $(SDL2_DIR)/src/sensor/dummy/*.c) \
+	$(wildcard $(SDL2_DIR)/src/stdlib/*.c) \
+	$(wildcard $(SDL2_DIR)/src/thread/*.c) \
+	$(wildcard $(SDL2_DIR)/src/thread/windows/*.c) \
+	$(wildcard $(SDL2_DIR)/src/timer/*.c) \
+	$(wildcard $(SDL2_DIR)/src/timer/windows/*.c) \
+	$(wildcard $(SDL2_DIR)/src/video/*.c) \
+	$(wildcard $(SDL2_DIR)/src/video/xbox/*.c) \
+	$(wildcard $(SDL2_DIR)/src/video/yuv2rgb/*.c)
 
 # Additions for Xbox
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/libm/*.c)
-SDL_SRCS += $(wildcard $(SDL_DIR)/src/atomic/*.c)
+SDL2_SRCS += \
+	$(wildcard $(SDL2_DIR)/src/libm/*.c) \
+	$(wildcard $(SDL2_DIR)/src/atomic/*.c)
 
-SRCS += $(SDL_SRCS)
-CFLAGS += -I$(SDL_DIR)/include \
-          -DXBOX
+NXDK_CFLAGS += -I$(SDL2_DIR)/include \
+               -DXBOX
 
-CXXFLAGS += -I$(SDL_DIR)/include \
-          -DXBOX
+NXDK_CXXFLAGS += -I$(SDL2_DIR)/include \
+                 -DXBOX
+
+SDL2_OBJS = $(addsuffix .obj, $(basename $(SDL2_SRCS)))
+
+$(NXDK_DIR)/lib/libSDL2.lib: $(SDL2_OBJS)
+
+main.exe: $(NXDK_DIR)/lib/libSDL2.lib
+
+CLEANRULES += clean-sdl2
+
+.PHONY: clean-sdl2
+clean-sdl2:
+	$(VE)rm -f $(SDL2_OBJS) $(NXDK_DIR)/lib/libSDL2.lib


### PR DESCRIPTION
This builds SDL2 as a library, primarily to make it easier to re-use it with other build systems.

I decided to keep the wildcard search for paths, because most other Makefiles for SDL also seem to do this (although, they do not use `$(wildcard path/*.c)`, but just `path/*.c`). The PSP platform does not do this, but we can look at this again in the future.

We'll probably have to revisit this in the future, because I assume that we'll eventually want to install libs and includes in standard folders (such as /usr/lib and /usr/include). Anyhow, this PR is "better than master" and good enough for now.