### PR TITLE
video: Writeback WC buffers when updating the window

### DIFF
--- a/src/video/xbox/SDL_xbframebuffer.c
+++ b/src/video/xbox/SDL_xbframebuffer.c
@@ -93,6 +93,9 @@ int SDL_XBOX_UpdateWindowFramebuffer(_THIS, SDL_Window * window, const SDL_Rect 
     // Copy SDL window surface to GPU framebuffer
     SDL_ConvertPixels(width, height, src_format, src, src_pitch, dst_format, dst, dst_pitch);
 
+    // Writeback WC buffers
+    XVideoFlushFB();
+
     return 0;
 }
 


### PR DESCRIPTION
We should assume that the framebuffer is write-combined (WC), but this means that data might be stuck in the write-combine buffers (where the GPU can't see it).
I have never observed any issues in practice, but in theory this could happen (I think).

As far as my understanding goes, `sfence` should be enough to write that data to RAM (I don't think WC memory uses the cache, so `wbinvd` would be overkill).

*This change was not tested yet!*