### PR TITLE
video: Make backend framebuffer formats consistent

### DIFF
--- a/src/video/xbox/SDL_xbframebuffer_c.h
+++ b/src/video/xbox/SDL_xbframebuffer_c.h
@@ -31,7 +31,7 @@ Uint32 pixelFormatSelector(int bpp) {
     Uint32 ret_val = 0;
     switch(bpp) {
     case 15:
-        ret_val = SDL_PIXELFORMAT_ARGB1555;
+        ret_val = SDL_PIXELFORMAT_RGB555;
         break;
     case 16:
         ret_val = SDL_PIXELFORMAT_RGB565;


### PR DESCRIPTION
This change improves consistency in the backend framebuffer pixel formats across 15,16 and 32 bpp modes by making them all have no alpha channel.