### PR TITLE
Re-enable pow()-usage

### DIFF
--- a/include/SDL_config_xbox.h
+++ b/include/SDL_config_xbox.h
@@ -95,7 +95,7 @@
 #define HAVE_LOGF 1
 #define HAVE_LOG10 1
 #define HAVE_LOG10F 1
-#undef HAVE_POW
+#define HAVE_POW 1
 #define HAVE_POWF 1
 #define HAVE_SIN 1
 #define HAVE_SINF 1


### PR DESCRIPTION
This reverts commit ed7840ad9675f6fd81f23d3ac2f124d0ca83d03a, since our PDCLib version now includes fixed versions of the math functions that used to cause the problem.