### PR TITLE
build: Add SDL2_test library

### DIFF
--- a/Makefile.xbox
+++ b/Makefile.xbox
@@ -33,6 +33,9 @@ SDL2_SRCS += \
 	$(wildcard $(SDL2_DIR)/src/libm/*.c) \
 	$(wildcard $(SDL2_DIR)/src/atomic/*.c)
 
+SDL2TEST_SRCS := \
+	$(wildcard $(SDL2_DIR)/src/test/*.c)
+
 NXDK_CFLAGS += -I$(SDL2_DIR)/include \
                -DXBOX
 
@@ -40,13 +43,17 @@ NXDK_CXXFLAGS += -I$(SDL2_DIR)/include \
                  -DXBOX
 
 SDL2_OBJS = $(addsuffix .obj, $(basename $(SDL2_SRCS)))
+SDL2TEST_OBJS = $(addsuffix .obj, $(basename $(SDL2TEST_SRCS)))
 
 $(NXDK_DIR)/lib/libSDL2.lib: $(SDL2_OBJS)
+$(NXDK_DIR)/lib/SDL2_test.lib: $(SDL2TEST_OBJS)
 
 main.exe: $(NXDK_DIR)/lib/libSDL2.lib
+main.exe: $(NXDK_DIR)/lib/SDL2_test.lib
 
 CLEANRULES += clean-sdl2
 
 .PHONY: clean-sdl2
 clean-sdl2:
 	$(VE)rm -f $(SDL2_OBJS) $(NXDK_DIR)/lib/libSDL2.lib
+	$(VE)rm -f $(SDL2TEST_OBJS) $(NXDK_DIR)/lib/SDL2_test.lib


### PR DESCRIPTION
Potentially used in https://github.com/Teufelchen1/libSDL_gfx/pull/2, but also useful for other purposes.

Library name omits lib prefix so autoconf can find it (I'm already using autoconf and cmake locally).
This is also how SDL2 would name it.

I did not try running it, but it compiles fine.