### PR TITLE
assert: Remove unistd dependency for nxdk

### DIFF
--- a/src/SDL_assert.c
+++ b/src/SDL_assert.c
@@ -39,7 +39,7 @@
 #else  /* fprintf, _exit(), etc. */
 #include <stdio.h>
 #include <stdlib.h>
-#if ! defined(__WINRT__)
+#if ! defined(__WINRT__) && ! defined(NXDK)
 #include <unistd.h>
 #endif
 #endif


### PR DESCRIPTION
Existence of unistd.h trips some build-systems, so I'd like to remove it from nxdk.
This avoids use of it in SDL2.