### PR TITLE
xbox: cpuinfo: Prevent SDL from undefining __MMX__ and __SSE

### DIFF
--- a/include/SDL_cpuinfo.h
+++ b/include/SDL_cpuinfo.h
@@ -32,7 +32,7 @@
 
 /* Need to do this here because intrin.h has C++ code in it */
 /* Visual Studio 2005 has a bug where intrin.h conflicts with winnt.h */
-#if defined(_MSC_VER) && (_MSC_VER >= 1500) && (defined(_M_IX86) || defined(_M_X64))
+#if (defined(_MSC_VER) && (_MSC_VER >= 1500) && (defined(_M_IX86) || defined(_M_X64))) && !defined(_XBOX)
 #ifdef __clang__
 /* Many of the intrinsics SDL uses are not implemented by clang with Visual Studio */
 #undef __MMX__


### PR DESCRIPTION
#37 seems stalled and this is a good catch.

Hopefully a maintainer can merge soon. Thanks!